### PR TITLE
Debug and fix failing GHA tests

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   playwright_e2e_tests:
     name: Playwright E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04  # Use Ubuntu 22.04 for better Playwright compatibility
     
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +25,12 @@ jobs:
       run: npm ci
     
     - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+      run: |
+        # Install browsers with fallback handling for OS compatibility
+        npx playwright install --with-deps || {
+          echo "Warning: Official browser installation failed, trying fallback..."
+          npx playwright install chromium
+        }
     
     - name: Run Playwright tests
       id: run_tests


### PR DESCRIPTION
Update GitHub Actions workflow to use Ubuntu 22.04 and add a Playwright browser installation fallback to fix test failures.

GitHub Actions' `ubuntu-latest` now defaults to Ubuntu 24.04, which Playwright does not yet officially support. This caused browser installation failures due to missing dependencies (e.g., `libicu74` vs `libicu76`), leading to all E2E tests failing. Changing to `ubuntu-22.04` and adding a fallback ensures stable browser setup.

---
[Slack Thread](https://t-start.slack.com/archives/D092PCQD9FH/p1755798844211809?thread_ts=1755798844.211809&cid=D092PCQD9FH)

<a href="https://cursor.com/background-agent?bcId=bc-7461858e-532f-4e42-a41d-089c9a59468e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7461858e-532f-4e42-a41d-089c9a59468e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

