### PR TITLE
Fix failing test automation in GHA

### DIFF
--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   playwright_e2e_tests:
     name: Playwright E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
     - uses: actions/checkout@v4
@@ -25,7 +25,11 @@ jobs:
       run: npm ci
     
     - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+      run: |
+        npx playwright install --with-deps || {
+          echo "Failed to install with deps, trying fallback..."
+          npx playwright install chromium
+        }
     
     - name: Run Playwright tests
       id: run_tests


### PR DESCRIPTION
Update Playwright E2E test workflow to use `ubuntu-22.04` and add a browser installation fallback for improved stability and compatibility.

The GitHub Actions workflow was failing because `ubuntu-latest` (Ubuntu 24.04) introduced compatibility issues with Playwright, specifically regarding missing system dependencies for browser installations. This change ensures a more stable environment and provides a fallback to install Chromium if the full dependency installation fails, preventing complete workflow failures.

---
[Slack Thread](https://t-start.slack.com/archives/D092PCQD9FH/p1755798844211809?thread_ts=1755798844.211809&cid=D092PCQD9FH)

<a href="https://cursor.com/background-agent?bcId=bc-42ce0b3b-44c6-44f1-a61f-716c9bace0c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42ce0b3b-44c6-44f1-a61f-716c9bace0c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

